### PR TITLE
Add AI Racing Engineer with voice button

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,9 @@ granturismo = {git = "https://github.com/chrshdl/granturismo.git"}
 blinkt = "*"
 rpi-lgpio = "*"
 scipy = "*"
+openai = "*"
+sounddevice = "*"
+soundfile = "*"
 
 [dev-packages]
 pre-commit = "*"

--- a/ai/__init__.py
+++ b/ai/__init__.py
@@ -1,0 +1,1 @@
+from .engineer import AIRacingEngineer

--- a/ai/engineer.py
+++ b/ai/engineer.py
@@ -1,0 +1,52 @@
+import os
+from typing import Any, Dict, List
+
+import openai
+from granturismo.model import Packet
+
+
+class AIRacingEngineer:
+    """Simple AI Racing Engineer using OpenAI's ChatCompletion API."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        api_key = api_key or os.getenv("OPENAI_API_KEY")
+        if api_key is None:
+            raise ValueError("OpenAI API key is required")
+        openai.api_key = api_key
+        try:
+            self.client = openai.OpenAI(api_key=api_key)
+        except AttributeError:
+            # fallback for older openai versions
+            self.client = openai
+
+    def _packet_info(self, packet: Packet) -> Dict[str, Any]:
+        info = {}
+        for name in dir(packet):
+            if name.startswith("_"):
+                continue
+            value = getattr(packet, name)
+            if not callable(value):
+                info[name] = value
+        return info
+
+    def answer(self, question: str, packet: Packet) -> str:
+        context = self._packet_info(packet)
+        messages: List[Dict[str, str]] = [
+            {
+                "role": "system",
+                "content": (
+                    "You are an AI Racing Engineer. Use the provided telemetry data to "
+                    "answer the user's questions as briefly as possible."
+                ),
+            },
+            {
+                "role": "system",
+                "content": f"Telemetry: {context}",
+            },
+            {"role": "user", "content": question},
+        ]
+        chat = self.client.chat.completions.create(
+            model="gpt-4o-mini-realtime-preview-2024-12-17",
+            messages=messages,
+        )
+        return chat.choices[0].message.content

--- a/hmi/views/dashboard.py
+++ b/hmi/views/dashboard.py
@@ -1,6 +1,7 @@
 import pygame
 from granturismo.model import Packet
 
+from ai import AIRacingEngineer
 from events import HMI_VIEW_BUTTON_PRESSED
 from hmi.properties import Color
 from hmi.widgets.button import Button
@@ -11,12 +12,16 @@ from hmi.widgets.led import LED
 from hmi.widgets.minimap import Minimap
 from hmi.widgets.rpm import GraphicalRPM, SimpleRPM
 from hmi.widgets.speed import Speedometer
+from hmi.widgets.voice import VoiceButton
 
 
 class Dashboard:
-    def __init__(self):
+    def __init__(self, openai_api_key: str | None = None):
         self.screen = pygame.display.get_surface()
         self.telemetry = pygame.sprite.Group()
+        self.engineer = (
+            AIRacingEngineer(api_key=openai_api_key) if openai_api_key else None
+        )
 
         SimpleRPM(self.telemetry, 76, 33)
         GraphicalRPM(self.telemetry, 100, 40)
@@ -37,10 +42,15 @@ class Dashboard:
             Button(f"{labels[i]}", ((125 * (i % 4) + 120), 558), (115, 50), 40)
             for i in range(len(labels))
         ]
+        if self.engineer:
+            self.voice = VoiceButton((620, 558), self.engineer)
+            self.buttons.append(self.voice)
 
     def handle_events(self, events: list[pygame.event.Event]) -> None:
         for button in self.buttons:
             if button.is_pressed(events):
+                if isinstance(button, VoiceButton):
+                    button.toggle()
                 pygame.event.post(
                     pygame.event.Event(HMI_VIEW_BUTTON_PRESSED, message=button.text)
                 )
@@ -53,6 +63,8 @@ class Dashboard:
         for button in self.buttons:
             button.update(packet)
             button.render(self.screen)
+            if isinstance(button, VoiceButton):
+                button.update_packet(packet)
 
     def update_rpm_alerts(self, rpmin, rpmax):
         for sprite in self.telemetry.sprites():

--- a/hmi/widgets/button.py
+++ b/hmi/widgets/button.py
@@ -21,6 +21,8 @@ class Button:
         self.text: str = text
         self.position: tuple[int, int] = position
         self.size: tuple[int, int] = size
+        self.fs: int = fs
+        self.text_color: Color = text_color
         self.button: pygame.Surface = pygame.Surface(size).convert()
         self.rect = self.button.get_rect(topleft=position)
         self.button.fill(Color.DARK_GREY.rgb())
@@ -29,10 +31,8 @@ class Button:
         self.top: pygame.Color = pygame.Color(0, 0, 0)
         self.gradient_outline_color: ColorValues = Color.GREY.rgb()
         self.outline_color: ColorValues = outline_color.rgb()
-
-        font = pygame.font.Font(join("fonts", "pixeltype.ttf"), fs)
-
-        self.text_surf: pygame.Surface = font.render(f"{text}", False, text_color.rgb())
+        self._font_path = join("fonts", "pixeltype.ttf")
+        self.render_text()
 
     def update(self, packet: Packet):
         if self.text == "TCS":
@@ -121,6 +121,14 @@ class Button:
                 thickness,
                 4,
             )
+
+    def render_text(self) -> None:
+        font = pygame.font.Font(self._font_path, self.fs)
+        self.text_surf = font.render(f"{self.text}", False, self.text_color.rgb())
+
+    def set_text(self, text: str) -> None:
+        self.text = text
+        self.render_text()
 
     def draw_gradient(self, top: pygame.Color, bottom: ColorValues) -> None:
         w = self.button.get_rect().width

--- a/hmi/widgets/voice.py
+++ b/hmi/widgets/voice.py
@@ -1,0 +1,59 @@
+import tempfile
+import threading
+from typing import Optional
+
+import sounddevice as sd
+from granturismo.model import Packet
+from scipy.io import wavfile
+
+from ai import AIRacingEngineer
+from common.logger import Logger
+
+from .button import Button
+
+
+class VoiceButton(Button):
+    def __init__(self, position: tuple[int, int], engineer: AIRacingEngineer):
+        super().__init__("MIC", position, (115, 50), 40)
+        self.engineer = engineer
+        self.listening = False
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self.logger = Logger(self.__class__.__name__).get()
+        self.current_packet: Optional[Packet] = None
+
+    def _listen_loop(self) -> None:
+        fs = 16000
+        while not self._stop.is_set():
+            duration = 5
+            audio = sd.rec(int(duration * fs), samplerate=fs, channels=1)
+            sd.wait()
+            with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+                wavfile.write(f.name, fs, audio)
+                with open(f.name, "rb") as f_audio:
+                    try:
+                        transcript = self.engineer.client.audio.transcriptions.create(
+                            model="whisper-1", file=f_audio
+                        ).text
+                    except Exception as e:
+                        self.logger.error(f"transcription error: {e}")
+                        continue
+            if transcript.strip() and self.current_packet is not None:
+                try:
+                    answer = self.engineer.answer(transcript, self.current_packet)
+                    self.logger.info(f"AI response: {answer}")
+                except Exception as e:
+                    self.logger.error(f"AI error: {e}")
+
+    def toggle(self) -> None:
+        self.listening = not self.listening
+        self.set_text("PAUSE" if self.listening else "MIC")
+        if self.listening:
+            self._stop.clear()
+            self._thread = threading.Thread(target=self._listen_loop, daemon=True)
+            self._thread.start()
+        else:
+            self._stop.set()
+
+    def update_packet(self, packet: Packet) -> None:
+        self.current_packet = packet

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from typing import Any
 
@@ -51,7 +52,9 @@ class Main:
             self.states.update({Main.STATE_WIZARD: Wizard(conf.recent_connected)})
         else:
             self.states.update({Main.STATE_STARTUP: Startup(self.playstation_ip)})
-            self.states.update({Main.STATE_DASHBOARD: Dashboard()})
+            self.states.update(
+                {Main.STATE_DASHBOARD: Dashboard(os.getenv("OPENAI_API_KEY"))}
+            )
 
         self.state: str = next(iter(self.states))
 
@@ -124,7 +127,9 @@ class Main:
     def on_ip_changed(self, event):
         self.playstation_ip = event.data
         self.states.update({Main.STATE_STARTUP: Startup(self.playstation_ip)})
-        self.states.update({Main.STATE_DASHBOARD: Dashboard()})
+        self.states.update(
+            {Main.STATE_DASHBOARD: Dashboard(os.getenv("OPENAI_API_KEY"))}
+        )
         self.state = Main.STATE_STARTUP
 
 


### PR DESCRIPTION
## Summary
- integrate OpenAI `gpt-4o-mini-realtime-preview-2024-12-17`
- add `AIRacingEngineer` helper
- create `VoiceButton` widget for microphone/pause toggle
- show voice button in dashboard when API key is available
- wire dashboard to new AI feature and add new dependencies

## Testing
- `ruff check ai/engineer.py ai/__init__.py hmi/widgets/voice.py hmi/widgets/button.py hmi/views/dashboard.py main.py`
- `ruff format ai/engineer.py ai/__init__.py hmi/widgets/voice.py hmi/widgets/button.py hmi/views/dashboard.py main.py`
- `mypy ai/engineer.py ai/__init__.py hmi/widgets/voice.py hmi/widgets/button.py hmi/views/dashboard.py main.py` *(fails: missing stubs)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68696a4d74cc8323af27d5cb5c70d9f2